### PR TITLE
Fix lookahead bias in rolling average

### DIFF
--- a/stock_prediction.ipynb
+++ b/stock_prediction.ipynb
@@ -525,7 +525,7 @@
     "new_predictors = []\n",
     "\n",
     "for horizon in horizons:\n",
-    "    rolling_averages = sp500.rolling(horizon).mean()\n",
+    "    rolling_averages = sp500.rolling(horizon).mean().shift(1)\n",
     "    \n",
     "    ratio_column = f\"Close_Ratio_{horizon}\"\n",
     "    sp500[ratio_column] = sp500[\"Close\"] / rolling_averages[\"Close\"]\n",


### PR DESCRIPTION
## Summary
- fix rolling average computation to use only past data and avoid lookahead bias

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683f8c01c9f083208ea8079cd0e9a02e